### PR TITLE
Updated Ban tooltip to add ban counts

### DIFF
--- a/i18n/en_US.json
+++ b/i18n/en_US.json
@@ -44,6 +44,8 @@
   "PREF_OPEN_IN_APP": "Open Profiles in Steam",
   "TOOLTIP_ACTUAL_NAME": "Actual Name:",
   "TOOLTIP_PREVIOUS_NAME": "Previous Name:",
-  "TOOLTIP_HAS_BANS": "User has Bans on Record",
+  "TOOLTIP_BANS_DAYS": "day(s) since last ban",
+  "TOOLTIP_BANS_VAC": "VAC ban(s) on record",
+  "TOOLTIP_BANS_GAME": "game ban(s) on record",
   "TOOLTIP_NEW_ACCOUNT": "Account newer than 2 Months"
 }

--- a/src/components/TF2/Player/playerutils.tsx
+++ b/src/components/TF2/Player/playerutils.tsx
@@ -132,7 +132,14 @@ function buildIconList(player: PlayerInfo): React.ReactNode[] {
       </Tooltip>
     ),
     !!hasBans && (
-      <Tooltip className="mr-1" content={t('TOOLTIP_HAS_BANS')}>
+      <Tooltip
+        className="mr-1"
+        content={`${player.steamInfo?.vacBans ?? 0} ${t('TOOLTIP_BANS_VAC')}\n${
+          player.steamInfo?.gameBans ?? 0
+        } ${t('TOOLTIP_BANS_GAME')}\n${
+          player.steamInfo?.daysSinceLastBan ?? 0
+        } ${t('TOOLTIP_BANS_DAYS')}`}
+      >
         <ShieldAlert width={18} height={18} />
       </Tooltip>
     ),


### PR DESCRIPTION
Updated the tooltip for the VAC and Game ban counts to include the number of bans of each type and the time since last ban.

Updated the localization files to reflect this change. Each line in the tooltip is its own entry.

I used the "day(s)" trick to ensure proper grammar; Valve does this too so I don't see why we can't :P