### PR TITLE
New account fixes

### DIFF
--- a/src/api/servers/fakedata.ts
+++ b/src/api/servers/fakedata.ts
@@ -242,6 +242,9 @@ export const fakedata: ServerInfoResponse = {
         disconnected: false,
         lastSeen: 0,
       },
+      steamInfo: {
+        timeCreated: Date.now() / 1000 - 61 * 24 * 60 * 60, // 61 days before now
+      },
     },
     {
       steamID64: '324234424',
@@ -261,6 +264,9 @@ export const fakedata: ServerInfoResponse = {
         time: 2300,
         disconnected: false,
         lastSeen: 0,
+      },
+      steamInfo: {
+        timeCreated: Date.now() / 1000 - 59 * 24 * 60 * 60, // 59 days before now
       },
     },
   ],

--- a/src/components/TF2/Player/playerutils.tsx
+++ b/src/components/TF2/Player/playerutils.tsx
@@ -126,7 +126,7 @@ function buildIconList(player: PlayerInfo): React.ReactNode[] {
         <ScrollText width={18} height={18} />
       </Tooltip>
     ),
-    accCreationTime < 30 * 24 * 60 * 60 && ( // 2 Months
+    accCreationTime < 60 * 24 * 60 * 60 && ( // 2 Months
       <Tooltip className="mr-1" content={t('TOOLTIP_NEW_ACCOUNT')}>
         <CalendarClock width={18} height={18} />
       </Tooltip>

--- a/src/components/TF2/Player/playerutils.tsx
+++ b/src/components/TF2/Player/playerutils.tsx
@@ -105,6 +105,7 @@ function buildPlayerNote(customData: CustomData) {
 }
 
 function buildIconList(player: PlayerInfo): React.ReactNode[] {
+  const now = Date.now() / 1000;
   const alias = player.customData?.alias;
   const playerNote = player.customData?.playerNote;
   const tfbd = player.customData?.tfbd;
@@ -126,7 +127,7 @@ function buildIconList(player: PlayerInfo): React.ReactNode[] {
         <ScrollText width={18} height={18} />
       </Tooltip>
     ),
-    accCreationTime < 60 * 24 * 60 * 60 && ( // 2 Months
+    accCreationTime > now - 60 * 24 * 60 * 60 && ( // 2 Months
       <Tooltip className="mr-1" content={t('TOOLTIP_NEW_ACCOUNT')}>
         <CalendarClock width={18} height={18} />
       </Tooltip>


### PR DESCRIPTION
Fixes detection of new accounts and changed the detection threshold to match the 2 months specified in interface.

Accounts that are private (creation date is undefined) no longer erroneously appear as new.

Added fake data of accounts that are 59 and 61 days old for testing purposes. 