### PR TITLE
refac: add menuConstants file to store pages and menu items used for …

### DIFF
--- a/src/App/App.css
+++ b/src/App/App.css
@@ -23,6 +23,13 @@
   color: #0077ff;
 }
 
+.steam-api-key {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  margin-right: 2rem;
+}
+
 *::-webkit-scrollbar {
   width: 6px;
   height: 4px;

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -14,6 +14,7 @@ import { useModal } from '../Context';
 import { setLanguage, t } from '@i18n';
 import { getAllSettings, setSettingKey } from '@api/preferences';
 import { useMinimode } from '../Context';
+import { PAGES } from '../constants/menuConstants';
 
 const CantConnectModal = () => {
   return (
@@ -30,7 +31,6 @@ interface ConfigurationModalProps {
   closeModal: () => void;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const ConfigurationModal = ({ closeModal }: ConfigurationModalProps) => {
   const [steamAPIKey, setSteamAPIKey] = React.useState('');
   const [rconPassword, setRconPassword] = React.useState('mac_rcon');
@@ -45,13 +45,7 @@ const ConfigurationModal = ({ closeModal }: ConfigurationModalProps) => {
       <div className="justify-center items-center">
         <div className="flex justify-center">
           <a
-            style={{
-              overflow: 'hidden',
-              whiteSpace: 'nowrap',
-              textOverflow: 'ellipsis',
-              marginRight: '2rem',
-            }}
-            className="link"
+            className="link steam-api-key"
             href="https://steamcommunity.com/dev/apikey"
             target="_blank"
             rel="noopener noreferrer"
@@ -97,17 +91,17 @@ const ConfigurationModal = ({ closeModal }: ConfigurationModalProps) => {
 
 function App() {
   const { isMinimode } = useMinimode();
-  const [currentPage, setCurrentPage] = React.useState('');
+  const [currentPage, setCurrentPage] = React.useState(PAGES.PLAYER_LIST);
 
   const { closeModal, openModal, modalContent } = useModal();
 
   const renderPage = () => {
     switch (currentPage) {
-      case 'playerlist':
+      case PAGES.PLAYER_LIST:
         return <PlayerList />;
-      case 'preferences':
+      case PAGES.PREFERENCES:
         return <Preferences />;
-      case 'playerhistory':
+      case PAGES.PLAYER_HISTORY:
         return <PlayerHistory />;
       default:
         return <PlayerList />;
@@ -180,7 +174,7 @@ function App() {
       <Modal />
       {!isMinimode && (
         <div className="App-sidebar">
-          <SideMenu setCurrentPage={setCurrentPage} />
+          <SideMenu setCurrentPage={setCurrentPage} currentPage={currentPage} />
         </div>
       )}
       <div className="App-content">

--- a/src/Pages/Preferences/Preferences.css
+++ b/src/Pages/Preferences/Preferences.css
@@ -25,17 +25,18 @@
 
 .pref-password-reveal {
   width: 100%;
-  height: 100%;
+  height: calc(max-content);
   display: flex;
   align-items: center;
   justify-content: center;
   padding-left: 4px;
   padding-right: 4px;
+  margin-bottom: 3px;
 }
 
 .pref-password-reveal:hover {
   cursor: pointer;
-  background-color: var(--dark-bg-color);
+  background-color: var(--dark-hover-color);
   border-radius: 4px;
 }
 

--- a/src/Pages/Preferences/Preferences.tsx
+++ b/src/Pages/Preferences/Preferences.tsx
@@ -230,8 +230,12 @@ const Preferences = () => {
                 onChange={(e) =>
                   handleSettingChange('steamApiKey', e, 'internal')
                 }
+                withIcon
               />
-              <div onClick={() => setSteamApiKeyRevealed(!steamApiKeyRevealed)}>
+              <div
+                className="flex items-center"
+                onClick={() => setSteamApiKeyRevealed(!steamApiKeyRevealed)}
+              >
                 {steamApiKeyRevealed ? (
                   <EyeOff
                     width={24}
@@ -255,8 +259,12 @@ const Preferences = () => {
                 onChange={(e) =>
                   handleSettingChange('rconPassword', e, 'internal')
                 }
+                withIcon
               />
-              <div onClick={() => setRconRevealed(!rconRevealed)}>
+              <div
+                className="flex items-center"
+                onClick={() => setRconRevealed(!rconRevealed)}
+              >
                 {rconRevealed ? (
                   <EyeOff
                     width={24}

--- a/src/components/General/SideMenu/SideMenu.tsx
+++ b/src/components/General/SideMenu/SideMenu.tsx
@@ -1,16 +1,17 @@
 import React, { Dispatch, SetStateAction } from 'react';
-import { History, Settings2, Users2 } from 'lucide-react';
 import { Divider, SideMenuItem } from '@components/General';
 import MenuHeader from './MenuHeader';
 
 import { t } from '@i18n';
 import './SideMenu.css';
+import { MENU_ITEMS, PAGES } from '../../../constants/menuConstants';
 
 interface SideMenuProps {
-  setCurrentPage: Dispatch<SetStateAction<string>>;
+  setCurrentPage: Dispatch<SetStateAction<PAGES>>;
+  currentPage: PAGES;
 }
 
-const SideMenu = ({ setCurrentPage }: SideMenuProps) => {
+const SideMenu = ({ setCurrentPage, currentPage }: SideMenuProps) => {
   const [collapsed, setCollapsed] = React.useState(true);
   const MenuRef = React.useRef<HTMLDivElement>(null);
 
@@ -58,24 +59,15 @@ const SideMenu = ({ setCurrentPage }: SideMenuProps) => {
         />
         <div>
           <Divider size={2} />
-          <SideMenuItem
-            title={t('PLAYERLIST')}
-            Icon={<Users2 />}
-            collapsed={collapsed}
-            onClick={() => setCurrentPage('playerlist')}
-          />
-          <SideMenuItem
-            title={t('PLAYERHISTORY')}
-            Icon={<History />}
-            collapsed={collapsed}
-            onClick={() => setCurrentPage('playerhistory')}
-          />
-          <SideMenuItem
-            title={t('PREFERENCES')}
-            Icon={<Settings2 />}
-            collapsed={collapsed}
-            onClick={() => setCurrentPage('preferences')}
-          />
+          {MENU_ITEMS.map(({ titleKey, icon, page }) => (
+            <SideMenuItem
+              title={t(titleKey)}
+              Icon={icon}
+              collapsed={collapsed}
+              onClick={() => setCurrentPage(page)}
+              selected={currentPage === page}
+            />
+          ))}
         </div>
       </div>
       <div

--- a/src/components/General/SideMenuItem/SideMenuItem.tsx
+++ b/src/components/General/SideMenuItem/SideMenuItem.tsx
@@ -8,6 +8,7 @@ interface SideMenuItemProps {
   Icon?: ReactElement;
   onClick?: () => void;
   collapsed?: boolean;
+  selected?: boolean;
 }
 
 const SideMenuItem = ({
@@ -15,6 +16,7 @@ const SideMenuItem = ({
   Icon = <Book />,
   onClick,
   collapsed = false,
+  selected = false,
 }: SideMenuItemProps) => {
   const SideMenuInner = () => {
     return (
@@ -33,9 +35,9 @@ const SideMenuItem = ({
 
   return (
     <div
-      className={`sm-item-outer max-h-[52px] p-3 transition-all whitespace-nowrap hover:bg-highlight/5 hover:bg hover:cursor-pointer ${
-        collapsed ? 'collapsed' : ''
-      }`}
+      className={`sm-item-outer max-h-[52px] p-3 transition-all whitespace-nowrap ${
+        selected ? 'bg-highlight/10' : 'hover:bg-highlight/5'
+      } hover:cursor-pointer ${collapsed ? 'collapsed' : ''}`}
       onClick={onClick}
     >
       {collapsed ? (

--- a/src/components/General/TextInput/TextInput.css
+++ b/src/components/General/TextInput/TextInput.css
@@ -1,6 +1,6 @@
 .text-input {
   border: none;
-  border-bottom: 2px solid white;
+  border-bottom: 1px solid white;
   background-color: var(--dark-bg-color);
   color: white;
   padding: 3px;
@@ -9,4 +9,10 @@
 
 .text-input:focus {
   outline: none;
+  border-bottom: 2px solid white;
+}
+
+.with-icon {
+  width: calc(100% + 26px);
+  padding-right: 28px;
 }

--- a/src/components/General/TextInput/TextInput.tsx
+++ b/src/components/General/TextInput/TextInput.tsx
@@ -6,6 +6,7 @@ interface TextInputProps {
   onChange?: (event: string) => void;
   placeholder?: string;
   type?: string;
+  withIcon?: boolean;
 }
 
 const TextInput = ({
@@ -13,6 +14,7 @@ const TextInput = ({
   onChange,
   placeholder,
   type = 'text',
+  withIcon = false,
 }: TextInputProps) => {
   const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
     const inputValue = event.target.value;
@@ -23,7 +25,7 @@ const TextInput = ({
     <div className="text-input-container">
       <input
         type={type}
-        className="text-input"
+        className={`text-input ${withIcon ? 'with-icon' : ''}`}
         placeholder={placeholder}
         value={value}
         onChange={handleInputChange}

--- a/src/constants/menuConstants.tsx
+++ b/src/constants/menuConstants.tsx
@@ -1,0 +1,32 @@
+import { History, Settings2, Users2 } from 'lucide-react';
+import React, { ReactElement } from 'react';
+
+export const enum PAGES {
+  PLAYER_HISTORY,
+  PLAYER_LIST,
+  PREFERENCES,
+}
+
+interface MenuItem {
+  titleKey: string;
+  icon: ReactElement;
+  page: PAGES;
+}
+
+export const MENU_ITEMS: MenuItem[] = [
+  {
+    titleKey: 'PLAYERLIST',
+    icon: <Users2 />,
+    page: PAGES.PLAYER_LIST,
+  },
+  {
+    titleKey: 'PLAYERHISTORY',
+    icon: <History />,
+    page: PAGES.PLAYER_HISTORY,
+  },
+  {
+    titleKey: 'PREFERENCES',
+    icon: <Settings2 />,
+    page: PAGES.PREFERENCES,
+  },
+];


### PR DESCRIPTION
- add menuConstants file to store pages and menu items used for submenu
- update styling for submenu so selected item has a visual indicator that it is selected
- update text input to give it prop to adjust styling so icon does not appear misplaced beside field
- update styling on text input so bottom border is thicker when clicked on (give better visual which field is currently selected)