### PR TITLE
minimode excludes disconnected; team layout matches bigmode

### DIFF
--- a/src/components/TF2/MiniScoreboard/MiniScoreboard.tsx
+++ b/src/components/TF2/MiniScoreboard/MiniScoreboard.tsx
@@ -17,17 +17,21 @@ interface MSBContentProps {
 }
 
 function calculateSusAndCheater(players: PlayerInfo[]): Verdicts {
-  const cheating = players?.filter(
+  const playersInGame = players?.filter(
+    (player) => !player.gameInfo.disconnected,
+  );
+
+  const cheating = playersInGame?.filter(
     (player) =>
       player.localVerdict?.toLowerCase() === 'cheater' ||
       player.localVerdict?.toLowerCase() === 'bot' ||
       player.convicted,
   );
-  const suspicious = players?.filter(
+  const suspicious = playersInGame?.filter(
     (player) => player.localVerdict?.toLowerCase() === 'suspicious',
   );
 
-  const convicted = players?.filter((player) => player.convicted);
+  const convicted = playersInGame?.filter((player) => player.convicted);
 
   return { suspicious, cheating, convicted };
 }
@@ -61,8 +65,8 @@ const MiniScoreboard = ({ RED, BLU }: MiniScoreboardProps) => {
   return (
     <>
       <div className="miniscore-container">
-        {RED && <MiniScoreboardContent verdicts={verdictsRED} team="red" />}
         {BLU && <MiniScoreboardContent verdicts={verdictsBLU} team="blu" />}
+        {RED && <MiniScoreboardContent verdicts={verdictsRED} team="red" />}
       </div>
     </>
   );


### PR DESCRIPTION
Intended to fix https://github.com/MegaAntiCheat/MegaAntiCheat-UI/issues/42 (yes, the guy put it on the wrong repo initially, hence the branch name being issue101)

Also swapped the position of the BLU and RED teams so BLU is first, as it is in both of the other layouts (standard & vertical window mode)