### PR TITLE
Improve app responsiveness to player data changes

### DIFF
--- a/src/components/TF2/Player/Notes/PlayerNotebox.tsx
+++ b/src/components/TF2/Player/Notes/PlayerNotebox.tsx
@@ -59,7 +59,8 @@ const PlayerNotebox = ({ player }: PlayerNoteBoxProps) => {
         className="hover:cursor-pointer"
         onClick={async () => {
           if (noteSentStatus != SentState.IDLE) return;
-
+          const old = player.customData.playerNote;
+          player.customData.playerNote = playerNote;
           setNoteSentStatus(SentState.SENDING);
 
           try {
@@ -72,6 +73,7 @@ const PlayerNotebox = ({ player }: PlayerNoteBoxProps) => {
             setNoteSentStatus(SentState.SUCCESS); // Success
           } catch (e) {
             setNoteSentStatus(SentState.FAILED); // Failed
+            player.customData.playerNote = old;
           }
 
           setTimeout(() => {

--- a/src/components/TF2/Player/Player.tsx
+++ b/src/components/TF2/Player/Player.tsx
@@ -64,7 +64,13 @@ const Player = ({
   const displayTime = formatTimeToString(playtime);
   const displayStatus = displayProperStatus(player.gameInfo!.state!);
   const displayName = player.customData?.alias || player.name;
-  let color = displayColor(playerColors!, player, cheatersInLobby);
+  // const color = displayColor(playerColors!, player, cheatersInLobby);
+  const [color, setColor] = React.useState<string | undefined>(undefined);
+  React.useEffect(() => {
+    console.log('immediate update');
+    setColor(displayColor(playerColors!, player, cheatersInLobby));
+    
+  }, [player.localVerdict]);
 
   const localizedLocalVerdictOptions = makeLocalizedVerdictOptions();
 
@@ -186,15 +192,10 @@ const Player = ({
           placeholder={displayVerdict}
           disabled={player.isSelf}
           onChange={(e) => {
-            updatePlayer(player.steamID64, e.toString());
             // Immediately update local instance
             // Causes new info to immediately show
             player.localVerdict = e.toString();
-            color = displayColor(playerColors!, player, cheatersInLobby);
-            const newColour = color ? `background-color: ${color}` : '';
-            document
-              .getElementById(`player-display-div-${player.steamID64}`)
-              ?.setAttribute('style', newColour);
+            updatePlayer(player.steamID64, e.toString());
           }}
         />
         <div onClick={() => setShowPlayerDetails(!showPlayerDetails)}>

--- a/src/components/TF2/Player/Player.tsx
+++ b/src/components/TF2/Player/Player.tsx
@@ -64,7 +64,7 @@ const Player = ({
   const displayTime = formatTimeToString(playtime);
   const displayStatus = displayProperStatus(player.gameInfo!.state!);
   const displayName = player.customData?.alias || player.name;
-  const color = displayColor(playerColors!, player, cheatersInLobby);
+  let color = displayColor(playerColors!, player, cheatersInLobby);
 
   const localizedLocalVerdictOptions = makeLocalizedVerdictOptions();
 
@@ -175,6 +175,7 @@ const Player = ({
         className={`player-item items-center py-0.5 px-1 grid grid-cols-playersm xs:grid-cols-player hover:bg-highlight/5 ${
           showPlayerDetails ? 'expanded' : ''
         } ${className}`}
+        id={`player-display-div-${player.steamID64}`}
         style={{
           backgroundColor: color,
         }}
@@ -189,6 +190,11 @@ const Player = ({
             // Immediately update local instance
             // Causes new info to immediately show
             player.localVerdict = e.toString();
+            color = displayColor(playerColors!, player, cheatersInLobby);
+            const newColour = color ? `background-color: ${color}` : '';
+            document
+              .getElementById(`player-display-div-${player.steamID64}`)
+              ?.setAttribute('style', newColour);
           }}
         />
         <div onClick={() => setShowPlayerDetails(!showPlayerDetails)}>

--- a/src/components/TF2/Player/Player.tsx
+++ b/src/components/TF2/Player/Player.tsx
@@ -64,14 +64,16 @@ const Player = ({
   const displayTime = formatTimeToString(playtime);
   const displayStatus = displayProperStatus(player.gameInfo!.state!);
   const displayName = player.customData?.alias || player.name;
+
   // const color = displayColor(playerColors!, player, cheatersInLobby);
-  
+
   const [color, setColor] = React.useState<string | undefined>(
     displayColor(playerColors!, player, cheatersInLobby),
   );
+
   React.useEffect(() => {
     setColor(displayColor(playerColors!, player, cheatersInLobby));
-  }, [player.localVerdict]);
+  }, [player.localVerdict, playerColors, player, cheatersInLobby]);
 
   const localizedLocalVerdictOptions = makeLocalizedVerdictOptions();
 

--- a/src/components/TF2/Player/Player.tsx
+++ b/src/components/TF2/Player/Player.tsx
@@ -196,7 +196,7 @@ const Player = ({
           disabled={player.isSelf}
           onChange={(e) => {
             // Immediately update local instance
-            // Causes new info to imm{ediately show
+            // Causes new info to immediately show
             player.localVerdict = e.toString();
             updatePlayer(player.steamID64, e.toString());
             setColor(displayColor(playerColors!, player, cheatersInLobby));

--- a/src/components/TF2/Player/Player.tsx
+++ b/src/components/TF2/Player/Player.tsx
@@ -65,11 +65,12 @@ const Player = ({
   const displayStatus = displayProperStatus(player.gameInfo!.state!);
   const displayName = player.customData?.alias || player.name;
   // const color = displayColor(playerColors!, player, cheatersInLobby);
-  const [color, setColor] = React.useState<string | undefined>(undefined);
+  
+  const [color, setColor] = React.useState<string | undefined>(
+    displayColor(playerColors!, player, cheatersInLobby),
+  );
   React.useEffect(() => {
-    console.log('immediate update');
     setColor(displayColor(playerColors!, player, cheatersInLobby));
-    
   }, [player.localVerdict]);
 
   const localizedLocalVerdictOptions = makeLocalizedVerdictOptions();
@@ -193,7 +194,7 @@ const Player = ({
           disabled={player.isSelf}
           onChange={(e) => {
             // Immediately update local instance
-            // Causes new info to immediately show
+            // Causes new info to imm{ediately show
             player.localVerdict = e.toString();
             updatePlayer(player.steamID64, e.toString());
           }}

--- a/src/components/TF2/Player/Player.tsx
+++ b/src/components/TF2/Player/Player.tsx
@@ -199,6 +199,7 @@ const Player = ({
             // Causes new info to imm{ediately show
             player.localVerdict = e.toString();
             updatePlayer(player.steamID64, e.toString());
+            setColor(displayColor(playerColors!, player, cheatersInLobby));
           }}
         />
         <div onClick={() => setShowPlayerDetails(!showPlayerDetails)}>

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -991,10 +991,6 @@ video {
   overflow-x: auto;
 }
 
-.overflow-y-auto {
-  overflow-y: auto;
-}
-
 .overflow-x-hidden {
   overflow-x: hidden;
 }


### PR DESCRIPTION
Had a few gripes when using the front end:

Setting notes was slow to do - you'd press the button and then the icon with the note wouldn't appear for a while until the next sync from the backend. 
- Make the set note button also set the local data on change. The next sync packet should reflect the exact same data anyway

Changing the player verdict took a small while before the colour of the div changes
- Make the onChange() event for the player verdict dropdown set the style attribute of the parent div as well
- This required adding an 'id' field to each player div object in the list, which is easy to do because we already have unique SID64's attached to each player object.

App feels a little more responsive now