### PR TITLE
feat: add ability to sort team tables in either desc or asc order for each column

### DIFF
--- a/src/components/TF2/Player/playerutils.tsx
+++ b/src/components/TF2/Player/playerutils.tsx
@@ -11,29 +11,7 @@ import {
   Users2,
 } from 'lucide-react';
 import { Tooltip } from '@components/General';
-
-const localVerdict = [
-  {
-    label: 'PLAYER',
-    value: 'Player',
-  },
-  {
-    label: 'BOT',
-    value: 'Bot',
-  },
-  {
-    label: 'CHEATER',
-    value: 'Cheater',
-  },
-  {
-    label: 'SUSPICIOUS',
-    value: 'Suspicious',
-  },
-  {
-    label: 'TRUSTED',
-    value: 'Trusted',
-  },
-];
+import { LOCAL_VERDICT_OPTIONS } from '../../../constants/playerConstants';
 
 function calculateKD(kills: number = 0, deaths: number = 0): string {
   // No Kills, No KD
@@ -47,7 +25,9 @@ function calculateKD(kills: number = 0, deaths: number = 0): string {
 function localizeVerdict(verdict: string | undefined) {
   if (!verdict || verdict.toLowerCase() === 'none') return t('PLAYER');
 
-  const option = localVerdict.find((option) => option.value === verdict);
+  const option = LOCAL_VERDICT_OPTIONS.find(
+    (option) => option.value === verdict,
+  );
 
   if (!option) console.error('Invalid verdict: ', verdict);
 
@@ -55,7 +35,7 @@ function localizeVerdict(verdict: string | undefined) {
 }
 
 function makeLocalizedVerdictOptions() {
-  return localVerdict.map((option) => ({
+  return LOCAL_VERDICT_OPTIONS.map((option) => ({
     label: t(option.label.toUpperCase()),
     value: option.value,
   }));

--- a/src/components/TF2/ScoreboardTable/SortableTableHeader.tsx
+++ b/src/components/TF2/ScoreboardTable/SortableTableHeader.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+import { t } from '@i18n';
+import {
+  ArrowDownUp,
+  ArrowDownWideNarrow,
+  ArrowUpNarrowWide,
+} from 'lucide-react';
+import {
+  SORT_TYPES,
+  SortableHeader,
+  TableHeaderSorting,
+} from '../../../constants/tableConstants';
+
+interface SortableTableHeaderProps {
+  header: SortableHeader;
+  changeSort: (sorting: TableHeaderSorting) => void;
+  currentSort: TableHeaderSorting;
+}
+
+export const SortableTableHeader = ({
+  header,
+  changeSort,
+  currentSort,
+}: SortableTableHeaderProps) => {
+  const SortIcon = ({ size }: { size: number }) => {
+    if (currentSort.sortValue === header.sortValue) {
+      switch (currentSort.sortType) {
+        case SORT_TYPES.SORT_ASC: {
+          return <ArrowUpNarrowWide size={size} />;
+        }
+        case SORT_TYPES.SORT_DESC: {
+          return <ArrowDownWideNarrow size={size} />;
+        }
+      }
+    }
+
+    return <ArrowDownUp size={size} />;
+  };
+
+  return (
+    <button
+      className={`gap-1 items-center ${
+        header?.hideWhenSmall ? 'xs:flex hidden' : 'flex'
+      }`}
+      onClick={() => {
+        changeSort({
+          sortValue: header.sortValue,
+          sortType:
+            currentSort.sortType === SORT_TYPES.SORT_ASC
+              ? SORT_TYPES.SORT_DESC
+              : SORT_TYPES.SORT_ASC,
+        });
+      }}
+    >
+      {t(header.nameKey)}
+      <SortIcon size={16} />
+    </button>
+  );
+};

--- a/src/constants/playerConstants.tsx
+++ b/src/constants/playerConstants.tsx
@@ -1,0 +1,35 @@
+export type VERDICT_TYPES =
+  | 'Player'
+  | 'Bot'
+  | 'Cheater'
+  | 'Suspicious'
+  | 'Trusted'
+  | 'None';
+
+interface VERDICT_OPTION {
+  label: string;
+  value: VERDICT_TYPES | string;
+}
+
+export const LOCAL_VERDICT_OPTIONS: VERDICT_OPTION[] = [
+  {
+    label: 'PLAYER',
+    value: 'Player',
+  },
+  {
+    label: 'BOT',
+    value: 'Bot',
+  },
+  {
+    label: 'CHEATER',
+    value: 'Cheater',
+  },
+  {
+    label: 'SUSPICIOUS',
+    value: 'Suspicious',
+  },
+  {
+    label: 'TRUSTED',
+    value: 'Trusted',
+  },
+];

--- a/src/constants/tableConstants.tsx
+++ b/src/constants/tableConstants.tsx
@@ -1,0 +1,50 @@
+import { VERDICT_TYPES } from './playerConstants';
+
+export enum SORT_TYPES {
+  UNSORTED,
+  SORT_ASC,
+  SORT_DESC,
+}
+
+export enum SORT_OPTIONS {
+  SORT_BY_USER,
+  SORT_BY_TIME,
+  SORT_BY_RATING,
+}
+
+export interface TableHeaderSorting {
+  sortValue: SORT_OPTIONS;
+  sortType: SORT_TYPES;
+}
+
+export interface SortableHeader {
+  sortValue: SORT_OPTIONS;
+  nameKey: string;
+  hideWhenSmall?: boolean;
+}
+
+export const DEFAULT_HEADER_SORT: TableHeaderSorting = {
+  sortValue: SORT_OPTIONS.SORT_BY_USER,
+  sortType: SORT_TYPES.UNSORTED,
+};
+
+export const SORTABLE_SCOREBOARD_HEADERS: SortableHeader[] = [
+  { sortValue: SORT_OPTIONS.SORT_BY_RATING, nameKey: 'TEAM_NAV_RATING' },
+  { sortValue: SORT_OPTIONS.SORT_BY_USER, nameKey: 'TEAM_NAV_USER' },
+  {
+    sortValue: SORT_OPTIONS.SORT_BY_TIME,
+    nameKey: 'TEAM_NAV_TIME',
+    hideWhenSmall: true,
+  },
+];
+
+export const RATING_SORT_ORDER: {
+  [Property in VERDICT_TYPES]: number;
+} = {
+  Trusted: 0,
+  Player: 1,
+  None: 1, // This should appear as "Player" either way
+  Suspicious: 2,
+  Cheater: 3,
+  Bot: 4,
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,9 +14,9 @@ module.exports = {
         outline: '#c5c6d1',
       },
       gridTemplateColumns: {
-        player: '122px minmax(100px, 1fr) max-content minmax(0px, 60px)',
+        player: '122px minmax(100px, 1fr) max-content minmax(0px, 75px)',
         playersm: '120px minmax(100px, 1fr) 18px',
-        scoreboardnav: '114px minmax(95px, 1fr) 55px',
+        scoreboardnav: '114px minmax(95px, 1fr) 70px',
         scoreboardnavsm: '180px 130px',
         scoreboardgrid: '1fr 3px 1fr',
         scoreboardgridsm: '1fr',


### PR DESCRIPTION
# Changelog:

- Replaced `const localVerdict` within `src/components/TF2/Player/playerutils.tsx` with `const  LOCAL_VERDICT_OPTIONS` from new file `playerConstants.tsx`
- Created new file `src/constants/playerConstants.tsx` containing the following:
  - `export type VERDICT_TYPES` which can be one of 6 strings (based on what I could find this value can be)
  - `interface VERDICT_OPTION` with structure `{ label: string, value: VERDICT_TYPES | string T}`
  - `export const LOCAL_VERDICT_OPTIONS: VERDICT_OPTION[]` (this is effectively just `const localVerdict` hence why it replaces it but using types)
- Created new component `src/components/TF2/ScoreboardTable/SortableTableHeader.tsx` that renders header as a button with a sort icon that reflects current sorting state
- Created new file `src/constants/tableConstants.tsx` containing the following:
  - `export enum SORT_TYPES` with values:
    - `UNSORTED`
    - `SORT_ASC`
    - `SORT_DESC`
  - `export enum SORT_OPTIONS` with values:
    - `SORT_BY_USER `
    - `SORT_BY_TIME`
    - `SORT_BY_RATING`
  - `export interface TableHeaderSorting` with structure `{ sortValue: SORT_OPTIONS, sortType: SORT_TYPES }`
  - `export interface SortableHeader` with structure `{ sortValue: SORT_OPTIONS, nameKey: string, hideWhenSmall?: boolean }` where name key is what is passed for translation purposes
  - `export const DEFAULT_HEADER_SORT: TableHeaderSorting` set to unsorted and sort by user
  - `export const SORTABLE_SCOREBOARD_HEADERS: SortableHeader[]` containing the 3 possible sorting options
  - `export const RATING_SORT_ORDER` which uses `VERDICT_TYPES` to make a simple way to define the "Rating" column is sorted via numbers
- Updated `src/components/TF2/ScoreboardTable/ScoreboardTable.tsx` to use new `<SortableTableHeader />` and constants from `tableConstants.tsx` to define sorting functionality. In all sorting cases, the current user is displayed at the top of the team's list
- Updated `tailwind.config.js` `gridTemplateColumns` so the new `<SortableHeader />` won't be weirdly squished or have the sorting icon off screen