### PR TITLE
Optimized layout for VSH and ZI

### DIFF
--- a/src/components/TF2/ScoreboardTable/ScoreboardTable.tsx
+++ b/src/components/TF2/ScoreboardTable/ScoreboardTable.tsx
@@ -124,6 +124,40 @@ const ScoreboardTable = ({
     );
   };
 
+  // For Versus Saxton Hale (and any other gamemodes with a significant team imbalance), we want to leave one half to RED team and the other half for BLU, SPEC, and UNASSIGNED.
+  if(RED.length >= 12 && RED.length > BLU.length + SPEC.length + UNASSIGNED.length + 8) {
+    return (
+      <div className="grid grid-cols-scoreboardgridsm lg:grid-cols-scoreboardgrid place-content-start text-center h-screen overflow-x-hidden">
+        <div>
+          {renderTeam(BLU, 'BLU')}
+          <div className="mb-10"/>
+          {renderTeam(SPEC, 'SPECTATOR')}
+          <div className="mb-10"/>
+          {renderTeam(UNASSIGNED, 'UNASSIGNED')}
+        </div>
+        <div className="scoreboard-divider lg:[display:block] h-auto bg-highlight/10 w-[1px] mt-0" />
+        {renderTeam(RED, 'RED')}        
+      </div>
+    );
+  }
+
+  // Need to do the opposite as well for zombie infection
+  if(BLU.length >= 12 && BLU.length > RED.length + SPEC.length + UNASSIGNED.length + 8) {
+    return (
+      <div className="grid grid-cols-scoreboardgridsm lg:grid-cols-scoreboardgrid place-content-start text-center h-screen overflow-x-hidden">
+        {renderTeam(BLU, 'BLU')}
+        <div className="scoreboard-divider lg:[display:block] h-auto bg-highlight/10 w-[1px] mt-0" />
+        <div>
+          {renderTeam(RED, 'RED')}
+          <div className="mb-10"/>
+          {renderTeam(SPEC, 'SPECTATOR')}
+          <div className="mb-10"/>
+          {renderTeam(UNASSIGNED, 'UNASSIGNED')}
+        </div>    
+      </div>
+    );
+  }
+
   return (
     <div className="grid grid-cols-scoreboardgridsm lg:grid-cols-scoreboardgrid place-content-start text-center h-screen overflow-x-hidden">
       {renderTeam(BLU, 'BLU')}

--- a/src/components/TF2/ScoreboardTable/ScoreboardTable.tsx
+++ b/src/components/TF2/ScoreboardTable/ScoreboardTable.tsx
@@ -125,7 +125,10 @@ const ScoreboardTable = ({
   };
 
   // For Versus Saxton Hale (and any other gamemodes with a significant team imbalance), we want to leave one half to RED team and the other half for BLU, SPEC, and UNASSIGNED.
-  if(RED.length >= 12 && RED.length > BLU.length + SPEC.length + UNASSIGNED.length + 8) {
+  if (
+    RED.length >= 12 &&
+    RED.length > BLU.length + SPEC.length + UNASSIGNED.length + 8
+  ) {
     return (
       <div className="grid grid-cols-scoreboardgridsm lg:grid-cols-scoreboardgrid place-content-start text-center h-screen overflow-x-hidden">
         <div>
@@ -134,13 +137,16 @@ const ScoreboardTable = ({
           {renderTeam(UNASSIGNED, 'UNASSIGNED')}
         </div>
         <div className="scoreboard-divider lg:[display:block] h-auto bg-highlight/10 w-[1px] mt-0" />
-        {renderTeam(RED, 'RED')}        
+        {renderTeam(RED, 'RED')}
       </div>
     );
   }
 
   // Need to do the opposite as well for zombie infection
-  if(BLU.length >= 12 && BLU.length > RED.length + SPEC.length + UNASSIGNED.length + 8) {
+  if (
+    BLU.length >= 12 &&
+    BLU.length > RED.length + SPEC.length + UNASSIGNED.length + 8
+  ) {
     return (
       <div className="grid grid-cols-scoreboardgridsm lg:grid-cols-scoreboardgrid place-content-start text-center h-screen overflow-x-hidden">
         {renderTeam(BLU, 'BLU')}
@@ -149,7 +155,7 @@ const ScoreboardTable = ({
           {renderTeam(RED, 'RED')}
           {renderTeam(SPEC, 'SPECTATOR')}
           {renderTeam(UNASSIGNED, 'UNASSIGNED')}
-        </div>    
+        </div>
       </div>
     );
   }

--- a/src/components/TF2/ScoreboardTable/ScoreboardTable.tsx
+++ b/src/components/TF2/ScoreboardTable/ScoreboardTable.tsx
@@ -90,14 +90,14 @@ const ScoreboardTable = ({
 
     return (
       // Keep the classname for the popoutinfo alignment
-      <div className={`scoreboard-grid-half ${teamName}`}>
+      <div className={`scoreboard-grid-half pb-[10px] ${teamName}`}>
         <div
-          className={`text-4xl font-build mt-4 mb-3 ${teamName?.toLowerCase()}`}
+          className={`text-4xl font-build mt-4 mb-1 ${teamName?.toLowerCase()}`}
         >
           {t(teamName ?? 'UNASSIGNED').toUpperCase()} (
           {team?.length - amountDisconnected})
         </div>
-        <div className="flex-1 ml-5 mb-5 text-start font-build grid grid-cols-scoreboardnavsm xs:grid-cols-scoreboardnav">
+        <div className="flex-1 ml-5 mb-2 text-start font-build grid grid-cols-scoreboardnavsm xs:grid-cols-scoreboardnav">
           <div>{t('TEAM_NAV_RATING')}</div>
           <div>{t('TEAM_NAV_USER')}</div>
           {/* <div className="hidden xs:[display:unset]">
@@ -105,7 +105,7 @@ const ScoreboardTable = ({
           </div> */}
           <div className="hidden xs:[display:unset]">{t('TEAM_NAV_TIME')}</div>
         </div>
-        <div className={`${teamName?.toLowerCase()} mb-4`}>
+        <div className={`${teamName?.toLowerCase()}`}>
           {team?.map((player) => (
             // Provide the Context Menu Provider to the Element
             <ContextMenuProvider key={player.steamID64}>
@@ -130,9 +130,7 @@ const ScoreboardTable = ({
       <div className="grid grid-cols-scoreboardgridsm lg:grid-cols-scoreboardgrid place-content-start text-center h-screen overflow-x-hidden">
         <div>
           {renderTeam(BLU, 'BLU')}
-          <div className="mb-10"/>
           {renderTeam(SPEC, 'SPECTATOR')}
-          <div className="mb-10"/>
           {renderTeam(UNASSIGNED, 'UNASSIGNED')}
         </div>
         <div className="scoreboard-divider lg:[display:block] h-auto bg-highlight/10 w-[1px] mt-0" />
@@ -149,9 +147,7 @@ const ScoreboardTable = ({
         <div className="scoreboard-divider lg:[display:block] h-auto bg-highlight/10 w-[1px] mt-0" />
         <div>
           {renderTeam(RED, 'RED')}
-          <div className="mb-10"/>
           {renderTeam(SPEC, 'SPECTATOR')}
-          <div className="mb-10"/>
           {renderTeam(UNASSIGNED, 'UNASSIGNED')}
         </div>    
       </div>


### PR DESCRIPTION
In Versus Saxton Hale, the teams are massively imbalanced. In that situation, there's a lot of empty space under BLU team that could be utilized for the spectator and unassigned teams.

This PR implements that change. I also messed with the margins to ensure all the rows stay aligned even when the 3 teams are stacked on each other with differing player counts.