### PR TITLE
Fix custom alias modals autoclosing 

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -147,7 +147,7 @@ function App() {
         await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait 1 second before retrying
       }
     } while (!connected);
-    if(dead) closeModal(); // If backend died, we need to remove the modal once it recovers.
+    if (dead) closeModal(); // If backend died, we need to remove the modal once it recovers.
     verifyConfigured();
   };
 


### PR DESCRIPTION
Custom alias modals are autoclosing because of a silly bug I introduced when I "fixed" the backend modal from not closing.

This PR fixes the problem.