### PR TITLE
Backend reconnect polling: modify polling behaviour to prevent async spam

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -162,13 +162,9 @@ function App() {
 
     // Don't verify backend if we're using fakedata (dev environment)
     if (useFakedata) return;
-
-    verificationRoutine();
     const intervalId = setInterval(verificationRoutine, 1000);
 
-    return () => {
-      clearInterval(intervalId);
-    };
+    return () => {clearInterval(intervalId)};
   }, [currentPage, isDead]);
 
   return (

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -165,7 +165,7 @@ function App() {
     const intervalId = setInterval(verificationRoutine, 1000);
 
     return () => {
-      clearInterval(intervalId)
+      clearInterval(intervalId);
     };
   }, [currentPage, isDead]);
 

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -91,6 +91,7 @@ const ConfigurationModal = ({ closeModal }: ConfigurationModalProps) => {
 
 function App() {
   const { isMinimode } = useMinimode();
+  const [isDead, setDead] = React.useState(false);
   const [currentPage, setCurrentPage] = React.useState(PAGES.PLAYER_LIST);
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -138,17 +139,15 @@ function App() {
   };
 
   const verificationRoutine = async () => {
-    let connected = false;
-    let dead = false;
-    do {
-      connected = await isBackendConnected();
-      if (!connected) {
-        dead = true;
-        await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait 1 second before retrying
+    if (await isBackendConnected()) {
+      if (isDead) {
+        setDead(false);
+        closeModal();
       }
-    } while (!connected);
-    if (dead) closeModal(); // If backend died, we need to remove the modal once it recovers.
-    verifyConfigured();
+      verifyConfigured();
+    } else {
+      if (!isDead) setDead(true);
+    }
   };
 
   React.useEffect(() => {
@@ -165,12 +164,12 @@ function App() {
     if (useFakedata) return;
 
     verificationRoutine();
-    const intervalId = setInterval(verificationRoutine, 1000);
+    let int = setInterval(verificationRoutine, 1000);
 
     return () => {
-      clearInterval(intervalId);
+      clearInterval(int);
     };
-  }, [currentPage]);
+  }, [currentPage, isDead]);
 
   return (
     <div className="App">

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -164,10 +164,10 @@ function App() {
     if (useFakedata) return;
 
     verificationRoutine();
-    let int = setInterval(verificationRoutine, 1000);
+    const intervalId = setInterval(verificationRoutine, 1000);
 
     return () => {
-      clearInterval(int);
+      clearInterval(intervalId);
     };
   }, [currentPage, isDead]);
 

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -164,7 +164,9 @@ function App() {
     if (useFakedata) return;
     const intervalId = setInterval(verificationRoutine, 1000);
 
-    return () => {clearInterval(intervalId)};
+    return () => {
+      clearInterval(intervalId)
+    };
   }, [currentPage, isDead]);
 
   return (

--- a/src/api/globals/index.ts
+++ b/src/api/globals/index.ts
@@ -20,7 +20,7 @@ export async function verifyBackend(): Promise<boolean> {
 
   return await fetch(SERVERFETCH, { signal: controller.signal })
     .then((res) => res.ok)
-    .catch((error) => false)
+    .catch(() => false)
     .finally(() => clearTimeout(timeoutId));
 }
 

--- a/src/api/globals/index.ts
+++ b/src/api/globals/index.ts
@@ -15,9 +15,13 @@ export const COMMAND_ENDPOINT = `${APIURL}/commands/v1`;
 export const useFakedata = process.env.NODE_ENV?.includes('development');
 
 export async function verifyBackend(): Promise<boolean> {
-  return await fetch(SERVERFETCH)
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 500);
+
+  return await fetch(SERVERFETCH, { signal: controller.signal })
     .then((res) => res.ok)
-    .catch(() => false);
+    .catch((error) => false)
+    .finally(() => clearTimeout(timeoutId));
 }
 
 export async function isBackendConfigured(): Promise<boolean> {


### PR DESCRIPTION
Discord@sharp14 identified that Firefox handles the asynchronous polling of the backend for connectivity differently to Chromium.

My understanding of the issue:

Originally the code in [App.tsx](https://github.com/MegaAntiCheat/MegaAntiCheat-UI/blob/92f1aca4048d36f3afc3867e1fef0bd0e70acab5/src/App/App.tsx#L140) would rest in a do-while loop until a connection with the backend is established. To prevent polling spam, there was an await on an empty timeout function to hault the JS thread in that executing context for 1000ms.  On top of this though, the primary React.useEffect for the App  would set the `verificationRoutine` function to execute on a 1000ms interval. I believe that in the Firefox  JS engine, this would result in multiple separate JS contexts all sitting in the do-while loop, running backend connectivity checks (Because the first context would sit in the do-while, and would not end before the JS interval invoked another copy of the verificationRoutine, which would be run simultanouesly rather than overlapping the existing routine).

The Chromium JS engine seems to handle this differently, perhaps it GC's or destroys the old routine context when spinning up a new one from the Interval statement. 

Anyway,

The Solution:

Change the behaviour of the verificationRoutine to not wait on no connection, instead its a run-once-and-return function, that handles the repeated polling of the backend via the original Interval statement. I have added an extra React state variable to hold the current connectivity status of the backend, which allows us to control the destruction of the 'Reconnecting...' modal  upon reconnection.

The problem:

Im bad at React and have no idea what im doing. This more consistently across Firefox and chrome only runs once per 1000ms (ON AVERAGE), but on reconnects, it will trigger the `closeModal()` method (and any associated print statements) like 7 times before the React stateful variable update is registered. Im not sure if this is because there are still many separate contexts all sitting inside this routine and running it once, or that change to the state variable results in the React.useEffect() method being invoked multiple times very rapidly. This may be due to React Strict Mode, or some other shenanigans i don't know enough to consider. Please help @megascatterbomb  or @meatmeatmeatmeatmeatmeat 