### PR TITLE
Chore/follow accordion pattern

### DIFF
--- a/src/components/General/Accordion/Accordion.css
+++ b/src/components/General/Accordion/Accordion.css
@@ -1,3 +1,0 @@
-.acc-icon.open {
-  @apply rotate-180;
-}

--- a/src/components/General/Accordion/Accordion.tsx
+++ b/src/components/General/Accordion/Accordion.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import { Divider, Flex } from '@components/General';
-import { ChevronDown } from 'lucide-react';
+import {ChevronDown, ChevronUp} from 'lucide-react';
 
 interface AccordionProps {
   title?: string;
@@ -28,8 +28,8 @@ const Accordion = ({
         onClick={toggleAccordion}
       >
         <div className="relative pr-3">
-          <ChevronDown
-            className={`acc-icon transition-all ${!isOpen && 'rotate-180'}`}
+          <ChevronUp
+            className={`acc-icon transition-all ${isOpen && 'rotate-180'}`}
           />
         </div>
         <h3 className="text-xl font-bold">{title}</h3>

--- a/src/components/General/Accordion/Accordion.tsx
+++ b/src/components/General/Accordion/Accordion.tsx
@@ -1,5 +1,4 @@
 import React, { ReactNode } from 'react';
-import './Accordion.css';
 import { Divider, Flex } from '@components/General';
 import { ChevronDown } from 'lucide-react';
 
@@ -30,7 +29,7 @@ const Accordion = ({
       >
         <div className="relative pr-3">
           <ChevronDown
-            className={`acc-icon transition-all ${isOpen ? 'open' : ''}`}
+            className={`acc-icon transition-all ${!isOpen && 'rotate-180'}`}
           />
         </div>
         <h3 className="text-xl font-bold">{title}</h3>


### PR DESCRIPTION
Make the accordions in the preferences section follow the same rotation patterns as those used in the 'players' page.
^ is closed
⌄ is open