### PR TITLE
Add more sites to view profiles in

### DIFF
--- a/i18n/en_US.json
+++ b/i18n/en_US.json
@@ -141,5 +141,6 @@
   "TERMS_OF_SERVICE": "Terms of Service",
   "TOS_HINT": "Masterbase features are unavailable until you agree to the terms of service.",
   "AGREE_TO_TOS": "Agree to TOS",
-  "GET_ONE_HERE": "get one here"
+  "GET_ONE_HERE": "get one here",
+  "CONFIRM_EXTERNAL_LINKS": "Confirm using links to external sites"
 }

--- a/src/Pages/Preferences/Preferences.tsx
+++ b/src/Pages/Preferences/Preferences.tsx
@@ -155,6 +155,17 @@ const Preferences = () => {
                 }
               />
             </Flex>
+            <Flex className="preference-option">
+              <div className="preference-title">
+                {t('CONFIRM_EXTERNAL_LINKS')}
+              </div>
+              <Checkbox
+                checked={settings.external?.confirmExternalLinks ?? true}
+                onChange={(e) =>
+                  handleSettingChange('confirmExternalLinks', e, 'external')
+                }
+              />
+            </Flex>
           </Accordion>
           <Accordion title={t('PREF_COLORS')} className="preference-accordion">
             <TextItem className="mr-9">{t('PREF_COLORS_PRECEDENCE')}</TextItem>

--- a/src/api/api.d.ts
+++ b/src/api/api.d.ts
@@ -2,6 +2,7 @@ interface Settings {
   external: {
     language?: string;
     openInApp?: boolean;
+    confirmExternalLinks?: boolean;
     colors?: {
       You: string;
       Player: string;

--- a/src/components/General/ContextMenu/ContextMenu.tsx
+++ b/src/components/General/ContextMenu/ContextMenu.tsx
@@ -1,4 +1,11 @@
-import { CSSProperties, useContext, useEffect, useRef, useState } from 'react';
+import {
+  CSSProperties,
+  MouseEvent,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import './ContextMenu.css';
 
 import { ContextMenuContext } from '@context';
@@ -18,7 +25,8 @@ const ContextMenuContent = () => {
     left: position.x,
   };
 
-  const onItemClick = (itemAction: () => void) => {
+  const onItemClick = (e: MouseEvent, itemAction: () => void) => {
+    e.stopPropagation();
     hideMenu();
     itemAction();
   };
@@ -88,8 +96,8 @@ const ContextMenuContent = () => {
           <div
             className="ctx-menu-item"
             key={item.label + index}
-            onClick={() => {
-              if (item?.onClick) onItemClick(item?.onClick);
+            onClick={(e) => {
+              if (item?.onClick) onItemClick(e, item?.onClick);
             }}
             onMouseEnter={() => onMouseEnter(index)}
             onMouseLeave={() => onMouseLeave(index)}
@@ -115,8 +123,8 @@ const ContextMenuContent = () => {
                   <div
                     key={menuItem.label + index}
                     className="ctx-menu-item"
-                    onClick={() => {
-                      if (menuItem?.onClick) onItemClick(menuItem?.onClick);
+                    onClick={(e) => {
+                      if (menuItem?.onClick) onItemClick(e, menuItem?.onClick);
                     }}
                   >
                     {menuItem.label}

--- a/src/components/TF2/Player/Modals/ConfirmNavigationModal.tsx
+++ b/src/components/TF2/Player/Modals/ConfirmNavigationModal.tsx
@@ -1,0 +1,66 @@
+import { Button, Checkbox } from '@components/General';
+import { useModal } from '@context';
+import React from 'react';
+
+interface ConfirmNavigationModalProps {
+  link: string;
+  onConfirm?: () => void;
+  onCancel?: () => void;
+  onDontShowAgain?: () => void;
+}
+
+const ConfirmNavigationModal = ({
+  link,
+  onConfirm,
+  onCancel,
+  onDontShowAgain,
+}: ConfirmNavigationModalProps) => {
+  const [dontShowAgain, setDontShowAgain] = React.useState(false);
+
+  const { closeModal } = useModal();
+
+  const handleAction = () => {
+    if (dontShowAgain) {
+      onDontShowAgain?.();
+    }
+    closeModal();
+  };
+
+  return (
+    <div>
+      <div className="mb-5 text-lg">
+        You are about to open a link to an external site:{' '}
+        {new URL(link).hostname}.
+        <br />
+        Are you sure you want to continue?
+      </div>
+      <div className="w-full flex gap-3 justify-end items-center">
+        Don't show this again
+        <Checkbox
+          checked={dontShowAgain}
+          onChange={(checked) => {
+            setDontShowAgain(checked);
+          }}
+        />
+        <Button
+          onClick={() => {
+            handleAction();
+            onCancel?.();
+          }}
+        >
+          Cancel
+        </Button>
+        <Button
+          onClick={() => {
+            handleAction();
+            onConfirm?.();
+          }}
+        >
+          Proceed
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmNavigationModal;

--- a/src/components/TF2/Player/Player.tsx
+++ b/src/components/TF2/Player/Player.tsx
@@ -25,6 +25,7 @@ import {
   convertSteamID64toSteamID2,
   convertSteamID64toSteamID3,
 } from '@api/steamid';
+import { profileLinks } from '../../../constants/playerConstants';
 
 interface PlayerProps {
   player: PlayerInfo;
@@ -129,11 +130,26 @@ const Player = ({
     });
   }, [player.steamInfo?.pfp]);
 
+  const formatUrl = (url: string) => {
+    url = url.replace('{{ID64}}', player.steamID64);
+    return url;
+  };
+
   const handleContextMenu = (event: MouseEvent<HTMLDivElement>) => {
     event.preventDefault();
     const menuItems: MenuItem[] = [
       {
         label: 'Open Profile',
+        multiOptions: [
+          {
+            label: 'Steam Profile',
+            onClick: () => parent.open(urlToOpen, '_blank'),
+          },
+          ...profileLinks.map(([name, url]) => ({
+            label: name,
+            onClick: () => parent.open(formatUrl(url), '_blank'),
+          })),
+        ],
         onClick: () => {
           parent.open(urlToOpen, '_blank');
         },

--- a/src/components/TF2/ScoreboardTable/ScoreboardTable.tsx
+++ b/src/components/TF2/ScoreboardTable/ScoreboardTable.tsx
@@ -20,7 +20,7 @@ const ScoreboardTable = ({
 }: ScoreboardTableProps) => {
   // Store the users playerID
   const [userSteamID, setUserSteamID] = useState('0');
-  const [playerSettings, setPlayerSettings] = useState<Settings['external']>({
+  const [settings, setSettings] = useState<Settings['external']>({
     colors: {
       You: 'none',
       Player: 'none',
@@ -33,18 +33,19 @@ const ScoreboardTable = ({
       Bot: 'none',
     },
     openInApp: false,
+    confirmExternalLinks: true,
   });
 
   useEffect(() => {
-    const fetchTeamColors = async () => {
+    const fetchSettings = async () => {
       try {
         const { external } = await getAllSettings(); // Replace this with the actual async function that fetches colors
-        setPlayerSettings(external);
+        setSettings(external);
       } catch (error) {
         console.error('Error fetching team colors:', error);
       }
     };
-    fetchTeamColors();
+    fetchSettings();
   }, []);
 
   useEffect(() => {
@@ -108,12 +109,12 @@ const ScoreboardTable = ({
             // Provide the Context Menu Provider to the Element
             <ContextMenuProvider key={player.steamID64}>
               <Player
-                playerColors={playerSettings.colors}
                 className={teamName?.toLowerCase()}
                 player={player}
                 key={player.steamID64}
-                openInApp={playerSettings.openInApp}
                 cheatersInLobby={cheaters}
+                settings={settings}
+                setSettings={setSettings}
               />
             </ContextMenuProvider>
           ))}

--- a/src/constants/playerConstants.ts
+++ b/src/constants/playerConstants.ts
@@ -1,6 +1,7 @@
 export const profileLinks = [
   ['Steamrep', 'https://steamrep.com/profiles/{{ID64}}'],
   ['Backpack.tf', 'https://backpack.tf/profiles/{{ID64}}'],
+  ['SteamHistory', 'https://steamhistory.net/id/{{ID64}}'],
   ['RGL', 'https://rgl.gg/Public/PlayerProfile?p={{ID64}}'],
   ['Logs.tf', 'https://logs.tf/profile/{{ID64}}'],
   ['Demos.tf', 'https://demos.tf/profiles/{{ID64}}'],

--- a/src/constants/playerConstants.ts
+++ b/src/constants/playerConstants.ts
@@ -1,0 +1,11 @@
+export const profileLinks = [
+  ['Steamrep', 'https://steamrep.com/profiles/{{ID64}}'],
+  ['Backpack.tf', 'https://backpack.tf/profiles/{{ID64}}'],
+  ['RGL', 'https://rgl.gg/Public/PlayerProfile?p={{ID64}}'],
+  ['Logs.tf', 'https://logs.tf/profile/{{ID64}}'],
+  ['Demos.tf', 'https://demos.tf/profiles/{{ID64}}'],
+  ['Trends.tf', 'https://trends.tf/player/{{ID64}}'],
+  ['ETF2L', 'https://etf2l.org/search/{{ID64}}'],
+  ['UGC', 'https://www.ugcleague.com/players_page.cfm?player_id={{ID64}}'],
+  ['Ozfortress', 'https://ozfortress.com/users/steam_id/{{ID64}}'],
+];


### PR DESCRIPTION
A useful feature of TF2BD is the ability to quickly look up players on a variety of websites to get some context about them. This was suggested by someone in [this discord thread](https://discord.com/channels/1112665618869661726/1281707067626750095), who also compiled the links.