### PR TITLE
Allow Ports to be set in settings!

### DIFF
--- a/src/Pages/Preferences/Preferences.tsx
+++ b/src/Pages/Preferences/Preferences.tsx
@@ -340,13 +340,24 @@ const Preferences = () => {
               <div className="preference-title">{t('PREF_RCON_PORT')}</div>
               <TextInput
                 type={'input'}
-                defaultValue={settings?.internal.rconPort}
+                defaultValue={settings?.internal.rconPort?.toString()}
                 onLeave={(e) => {
                   try {
                     const port = Number.parseInt(e);
+
+                    if (isNaN(port)) {
+                      throw new Error('Invalid port');
+                    }
+
+                    if (port < 1 || port > 65535) {
+                      throw new Error('Port out of range');
+                    }
+
                     handleSettingChange('rconPort', port, 'internal');
                     //eslint-disable-next-line no-empty
-                  } catch {}
+                  } catch {
+                    // Invalid port
+                  }
                 }}
               />
             </Flex>

--- a/src/api/api.d.ts
+++ b/src/api/api.d.ts
@@ -22,7 +22,7 @@ interface Settings {
     dumbAutokick?: boolean;
     masterbaseKey?: string;
     masterbaseHost?: string;
-    rconPort?: string;
+    rconPort?: number;
     tosAgreementDate?: string;
   };
 }

--- a/src/api/globals/index.ts
+++ b/src/api/globals/index.ts
@@ -1,6 +1,6 @@
-import { getAllSettings } from '@api/preferences';
+import { getAllSettings, getSetting } from '@api/preferences';
 
-export const port = 1984;
+export const port = (getSetting('port') as unknown as number) || 1984;
 export const APIURL = `http://localhost:${port}/mac`;
 export const SERVERFETCH = `${APIURL}/game/v1`;
 export const PLAYERFETCH = `${APIURL}/user/v1`;

--- a/src/api/preferences/index.ts
+++ b/src/api/preferences/index.ts
@@ -54,7 +54,7 @@ async function setSettings(newSettings: PreferenceResponse): Promise<void> {
 
 interface PreferenceResponse {
   internal: {
-    port?: number;
+    rconPort?: number;
     tosAgreementDate: string;
     tf2Directory: string;
     rconPassword: string;
@@ -97,7 +97,7 @@ export const defaultSettings: PreferenceResponse = {
     },
   },
   internal: {
-    port: 1984,
+    rconPort: 1984,
     friendsApiUsage: '',
     tf2Directory: '',
     steamApiKey: '',

--- a/src/api/preferences/index.ts
+++ b/src/api/preferences/index.ts
@@ -54,6 +54,7 @@ async function setSettings(newSettings: PreferenceResponse): Promise<void> {
 
 interface PreferenceResponse {
   internal: {
+    port?: number;
     tosAgreementDate: string;
     tf2Directory: string;
     rconPassword: string;
@@ -96,6 +97,7 @@ export const defaultSettings: PreferenceResponse = {
     },
   },
   internal: {
+    port: 1984,
     friendsApiUsage: '',
     tf2Directory: '',
     steamApiKey: '',
@@ -125,6 +127,21 @@ function mergeWithDefaults(
   return mergedSettings;
 }
 
+async function getSetting(key: string): Promise<unknown> {
+  try {
+    const settings = await getAllSettings();
+    if (key in settings.internal) {
+      return settings.internal[key as keyof typeof settings.internal];
+    } else if (key in settings.external) {
+      return settings.external[key as keyof typeof settings.external];
+    }
+    return null;
+  } catch (e) {
+    console.error(e);
+    return null;
+  }
+}
+
 async function getAllSettings(): Promise<PreferenceResponse> {
   try {
     const settings = await (await fetch(PREF_ENDPOINT)).json();
@@ -136,4 +153,4 @@ async function getAllSettings(): Promise<PreferenceResponse> {
   }
 }
 
-export { setSettingKey, setSettings, getAllSettings };
+export { setSettingKey, setSettings, getAllSettings, getSetting };


### PR DESCRIPTION
Allows you to set the rcon port in the UI settings, innovation.

TLDR; it makes the rcon port field functional and checks if the port is valid. 
Defaults to 1984

![image](https://github.com/user-attachments/assets/928e8877-fd14-468c-b9a0-8658fbd71fe2)


